### PR TITLE
#23 Fix GUIs not showing in Ardour 4

### DIFF
--- a/src/plugin/plugin.cpp
+++ b/src/plugin/plugin.cpp
@@ -742,7 +742,11 @@ intptr_t Plugin::dispatchProc(AEffect* effect, i32 opcode, i32 index, intptr_t v
 	DataPort* port;
 	RecursiveMutex* guard;
 
-	if(std::this_thread::get_id() == plugin->mainThreadId_) {
+	// Ardour seems to be sending effEditOpen on something else besides the main thread.
+	// However, we do want to send it to the control port, since that's where our
+	// bridge expects it.
+	if (opcode == effEditOpen ||
+	    std::this_thread::get_id() == plugin->mainThreadId_) {
 		port = &plugin->controlPort_;
 		guard = &plugin->guard_;
 	}


### PR DESCRIPTION
It seems ardour does not send effEditOpen on the main thread. This fix
makes sure the resulting Command::ShowWindow is sent to the right
control channel.