### PR TITLE
#23 Put processReplacing handling onto a different thread.

### DIFF
--- a/src/host/host.h
+++ b/src/host/host.h
@@ -43,11 +43,14 @@ private:
 	DataPort controlPort_;
 	DataPort callbackPort_;
 	DataPort audioPort_;
+	DataPort processReplacingPort_;
 
 	Event condition_;
 
 	HANDLE audioThread_;
+    HANDLE processReplacingThread_;
 	std::atomic_flag runAudio_;
+	std::atomic_flag runProcessReplacing_;
 
 	bool isEditorOpen_;
 
@@ -61,6 +64,7 @@ private:
 	void destroyEditorWindow();
 
 	void audioThread();
+	void processReplacingThread();
 
 	void handleGetDataBlock(DataFrame* frame);
 	void handleSetDataBlock(DataFrame* frame);
@@ -77,6 +81,7 @@ private:
 			intptr_t value, void* ptr, float opt);
 
 	static DWORD CALLBACK audioThreadProc(void* param);
+    static DWORD CALLBACK processReplacingThreadProc(void* param);
 
 	static LRESULT CALLBACK windowProc(HWND hwnd, UINT message, WPARAM wParam,
 			LPARAM lParam);

--- a/src/plugin/plugin.h
+++ b/src/plugin/plugin.h
@@ -42,10 +42,12 @@ private:
 
 	RecursiveMutex guard_;
 	RecursiveMutex audioGuard_;
+    RecursiveMutex processReplacingGuard_;
 
 	DataPort controlPort_;
 	DataPort callbackPort_;
 	DataPort audioPort_;
+    DataPort processReplacingPort_;
 
 	Event condition_;
 


### PR DESCRIPTION
Further fix for #23.

Ardour, when handling audioMasterAutomate, calls back into the plugin
using getParameter. It's unclear whether that's VST-legal or not, but at
the moment it seems to deadlock when processReplacing is going on at the
same time.

This commit moves processReplacing onto a thread+queue for itself,
releaving the deadlock.